### PR TITLE
Update automatic-3d-ken-burns.ipynb

### DIFF
--- a/automatic-3d-ken-burns.ipynb
+++ b/automatic-3d-ken-burns.ipynb
@@ -91,7 +91,8 @@
       "source": [
         "# Install dependencies\n",
         "!pip install cupy\n",
-        "!pip install moviepy"
+        "!pip install moviepy\n"
+        "!pip install gevent\n"
       ],
       "execution_count": 0,
       "outputs": []


### PR DESCRIPTION
Hi @agmm,
I encountered `ModuleNotFoundError` while running your notebook,
as @scienceapps also has opened an [issue](https://github.com/agmm/colab-3d-ken-burns/issues/1) quite a while ago.

Installing an additional dependency (`gevent`) fixed this problem.